### PR TITLE
feat: add option to override the padding for BottomAlertDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+- Add option `bottomAlertDialogPadding` to `BottomAlertDialogConfig` for specifying the empty space above the title of a dialog. By default it is an EdgeInsets with top 10px.
+
 ## 1.0.0
 - Flutter_dialogs and flutter_bottom_alert_dialogs combined into one package
 - Add default padding to the bottom alert dialog that is the size of the safe area of a device. You can disable this by setting `useSafeAreaPadding` to false.

--- a/lib/src/bottom_alert_dialog.dart
+++ b/lib/src/bottom_alert_dialog.dart
@@ -282,7 +282,7 @@ class BottomAlertDialog extends StatelessWidget {
             child: Stack(
               children: [
                 Padding(
-                  padding: const EdgeInsets.only(top: 10),
+                  padding: config.bottomAlertDialogPadding,
                   child: Align(
                     alignment: Alignment.center,
                     child: Column(

--- a/lib/src/bottom_alert_dialog_config.dart
+++ b/lib/src/bottom_alert_dialog_config.dart
@@ -29,6 +29,7 @@ class BottomAlertDialogConfig extends InheritedWidget {
     CloseButtonBuilder? closeButtonBuilder,
     this.yesText = "Yes",
     this.noText = "No",
+    this.bottomAlertDialogPadding = const EdgeInsets.only(top: 10),
     this.backgroundColor,
     super.key,
   })  : _buttonBuilder = buttonBuilder,
@@ -38,6 +39,10 @@ class BottomAlertDialogConfig extends InheritedWidget {
   final CloseButtonBuilder? _closeButtonBuilder;
   final String yesText;
   final String noText;
+
+  /// The padding that is put between the top of the dialog and the content.
+  /// This is by default const EdgeInsets.only(top:10).
+  final EdgeInsets bottomAlertDialogPadding;
   final Color? backgroundColor;
 
   ButtonBuilder get buttonBuilder =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dialogs
 description: A new Flutter package project.
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/Iconica-Development/flutter_dialogs
 
 environment:


### PR DESCRIPTION
We need to set the value to 0 in beep to make a popup 40 pixels instead of having 30+10 where 10 would be a magic number.